### PR TITLE
修正事件延迟绑定

### DIFF
--- a/views/book/index.tpl
+++ b/views/book/index.tpl
@@ -375,7 +375,7 @@
         /**
          * 创建项目
          */
-        $("#btnSaveDocument").on("click",function () {
+        $("body").on("click","#btnSaveDocument",function () {
             var $this = $(this);
 
 


### PR DESCRIPTION
由于bootstrap的modal，在第二次打开的时候是一个全新的dom，所以此处一定要使用jquery延迟绑定，否则添加完一个项目之后，业务不刷新的情况下，保存按钮无效