### PR TITLE
更新 Dockerfile 适配使用 MySQL 数据源

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ FROM alpine:latest
 LABEL maintainer="ehlxr.me@gmail.com"
 WORKDIR /mindoc
 COPY --from=0 /go/src/github.com/lifei6671/mindoc .
+ENV ZONEINFO=/mindoc/lib/time/zoneinfo.zip
 RUN chmod +x start.sh
 
 CMD ["./start.sh"]

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ mail_expired=30
 在启动镜像时需要提供如下的环境变量：
 
 ```ini
+DB_ADAPTER                  制定 DB
 MYSQL_PORT_3306_TCP_ADDR    MySQL地址
 MYSQL_PORT_3306_TCP_PORT    MySQL端口号
 MYSQL_INSTANCE_NAME         MySQL数据库名称

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 [![Build Status](https://travis-ci.org/lifei6671/mindoc.svg?branch=master)](https://travis-ci.org/lifei6671/mindoc)
 [![Build status](https://ci.appveyor.com/api/projects/status/ik70whjrioyvfy18/branch/master?svg=true)](https://ci.appveyor.com/project/lifei6671/godoc/branch/master)
 
-MinDoc 是一款针对IT团队开发的简单好用的文档管理系统。 
+MinDoc 是一款针对IT团队开发的简单好用的文档管理系统。
 
 MinDoc 的前身是 SmartWiki 文档系统。SmartWiki 是基于 PHP 框架 laravel 开发的一款文档管理系统。因 PHP 的部署对普通用户来说太复杂，所以改用 Golang 开发。可以方便用户部署和实用。
 
-开发缘起是公司IT部门需要一款简单实用的项目接口文档管理和分享的系统。其功能和界面源于 kancloud 。 
+开发缘起是公司IT部门需要一款简单实用的项目接口文档管理和分享的系统。其功能和界面源于 kancloud 。
 
 可以用来储存日常接口文档，数据库字典，手册说明等文档。内置项目管理，用户管理，权限管理等功能，能够满足大部分中小团队的文档管理需求。
 
@@ -39,7 +39,7 @@ go build -ldflags "-w"
 MinDoc 使用MySQL储存数据，且编码必须是`utf8mb4_general_ci`。请在安装前，把数据库配置填充到项目目录下的 conf/app.conf 中。
 
 如果conf目录下不存在 app.conf 请重命名 app.conf.example 为 app.conf。
- 
+
 **默认程序会自动初始化一个超级管理员用户：admin 密码：123456 。请登录后重新设置密码。**
 
 ## Linux 下后台运行
@@ -62,8 +62,8 @@ Windows 下后台运行需要借助 CMD 命令行命令：
 ```bash
 #在MinDoc跟目录下新建一个slave.vbs文件：
 
-Set ws = CreateObject("Wscript.Shell") 
-ws.run "cmd /c start.bat",vbhide 
+Set ws = CreateObject("Wscript.Shell")
+ws.run "cmd /c start.bat",vbhide
 
 #再建一个start.bat文件：
 @echo off
@@ -124,7 +124,7 @@ HTTP_PORT                   程序监听的端口号
 举个栗子
 
 ```bash
-docker run -p 8181:8181 -e MYSQL_PORT_3306_TCP_ADDR=127.0.0.1 -e MYSQL_PORT_3306_TCP_PORT=3306 -e MYSQL_INSTANCE_NAME=mindoc_db -e MYSQL_USERNAME=root -e MYSQL_PASSWORD=123456 -e httpport=8181 -d daocloud.io/lifei6671/mindoc:latest
+docker run -p 8181:8181 --name mindoc -e DB_ADAPTER=mysql -e MYSQL_PORT_3306_TCP_ADDR=10.xxx.xxx.xxx -e MYSQL_PORT_3306_TCP_PORT=3306 -e MYSQL_INSTANCE_NAME=mindoc -e MYSQL_USERNAME=root -e MYSQL_PASSWORD=123456 -e httpport=8181 -d daocloud.io/lifei6671/mindoc:latest
 ```
 ### docker-compose 一键安装
 1. 生成配置文件
@@ -135,7 +135,7 @@ docker run -p 8181:8181 -e MYSQL_PORT_3306_TCP_ADDR=127.0.0.1 -e MYSQL_PORT_3306
     > docker-compose up -d mindoc
 3. 浏览器访问
     > http://localhost:8181/
-    
+
     整个部署完成了
 4. 常用命令参考
    - 启动
@@ -143,10 +143,10 @@ docker run -p 8181:8181 -e MYSQL_PORT_3306_TCP_ADDR=127.0.0.1 -e MYSQL_PORT_3306
    - 停止
         > docker-compose stop mindoc
    - 重启
-        > docker-compose restart mindoc        
+        > docker-compose restart mindoc
    - 停止删除容器，释放所有资源
         > docker-compose down
-        
+
    更多 docker-compose 的使用相关的内容 请查看官网文档或百度
 
 # 项目截图


### PR DESCRIPTION
1、更新了 README：如果使用 MySQL 数据库，需要制定环境变量 DB_ADAPTER=mysql ，README 中描述使用 docker 启动的时候没有提及。

2、更新了 Dockerfile：如果使用 mysql 会提示找不到 zoneinfo.zip，Dockerfile 中添加了环境变量 ZONEINFO 指定到 lib/time/zoneinfo.zip