### PR TITLE
Fixed cannot display avatars when deployed to subdirectories

### DIFF
--- a/views/setting/index.tpl
+++ b/views/setting/index.tpl
@@ -73,7 +73,7 @@
                     <div class="form-right">
                         <label>
                             <a href="javascript:;" data-toggle="modal" data-target="#upload-logo-panel">
-                                <img src="{{.Member.Avatar}}" onerror="this.src='/static/images/middle.gif'" class="img-circle" alt="头像" style="max-width: 120px;max-height: 120px;" id="headimgurl">
+                                <img src="{{cdnimg .Member.Avatar}}" onerror="this.src='{{cdnimg "static/images/middle.gif"}}'" class="img-circle" alt="头像" style="max-width: 120px;max-height: 120px;" id="headimgurl">
                             </a>
                         </label>
                     </div>


### PR DESCRIPTION
子目录部署的时候，个人如果修改了头像，则设置页面无法正常显示且会不断报错