### PR TITLE
fix ReplaceAll function not defined error

### DIFF
--- a/models/DocumentModel.go
+++ b/models/DocumentModel.go
@@ -355,7 +355,7 @@ func (item *Document) Processor() *Document {
 						selection.SetAttr("href", "#")
 						return
 					}
-					val = strings.ReplaceAll(strings.ToLower(val), " ", "")
+					val = strings.Replace(strings.ToLower(val), " ", "",-1)
 					//移除危险脚本链接
 					if strings.HasPrefix(val, "data:text/html") ||
 						strings.HasPrefix(val, "vbscript:") ||


### PR DESCRIPTION
some version go strings libiary not define the ReplaceAll function,so if someone use that to  build from source code cause the compiler error, but the replace function is define all version.