### PR TITLE
fix bug about assignment mismatch

### DIFF
--- a/controllers/AccountController.go
+++ b/controllers/AccountController.go
@@ -437,14 +437,12 @@ func (c *AccountController) Logout() {
 func (c *AccountController) Captcha() {
 	c.Prepare()
 
-	captchaImage, err := gocaptcha.NewCaptchaImage(140, 40, gocaptcha.RandLightColor())
-
+	captchaImage:= gocaptcha.NewCaptchaImage(140, 40, gocaptcha.RandLightColor())
+	err:=captchaImage.DrawNoise(gocaptcha.CaptchaComplexLower)
 	if err != nil {
 		beego.Error(err)
 		c.Abort("500")
 	}
-
-	captchaImage.DrawNoise(gocaptcha.CaptchaComplexLower)
 
 	// captchaImage.DrawTextNoise(gocaptcha.CaptchaComplexHigh)
 	txt := gocaptcha.RandText(4)


### PR DESCRIPTION
the gocaptcha.NewCaptchaImage return one value,but the caller use two variable to receive  . in go 1.10.1 this cause compiler error,so i check the gocaptcha libairy's example ,the DrawNoise function can return the error type.