### PR TITLE
解决文档发布之后内容为空白

### DIFF
--- a/commands/command.go
+++ b/commands/command.go
@@ -34,6 +34,7 @@ func RegisterDataBase() {
 	beego.Info("正在初始化数据库配置.")
 	adapter := beego.AppConfig.String("db_adapter")
 	orm.DefaultTimeLoc = time.Local
+	orm.DefaultRowsLimit = -1
 
 	if strings.EqualFold(adapter, "mysql") {
 		host := beego.AppConfig.String("db_host")


### PR DESCRIPTION
Fixed #607

原因是 beego 的 `DefaultRowsLimit` 默认为 1000，导致文档数量超过 1000 条的时候，超出 1000 条的文档就不会从数据库查询出来，导致发布失败

较新版本的 beego 的 `DefaultRowsLimit` 的值默认是 -1，为了避免升级 beego，所以手动改成 -1